### PR TITLE
Make possible to sort by similarity of an existing pattern

### DIFF
--- a/levenshtein.py
+++ b/levenshtein.py
@@ -1,0 +1,21 @@
+
+def levenshtein(s1, s2):
+    if len(s1) < len(s2):
+        return levenshtein(s2, s1)
+
+    # len(s1) >= len(s2)
+    if len(s2) == 0:
+        return len(s1)
+
+    previous_row = range(len(s2) + 1)
+    for i, c1 in enumerate(s1):
+        current_row = [i + 1]
+        for j, c2 in enumerate(s2):
+            insertions = previous_row[j + 1] + 1 # j+1 instead of j since previous_row and current_row are one character longer
+            deletions = current_row[j] + 1       # than s2
+            substitutions = previous_row[j] + (c1 != c2)
+            current_row.append(min(insertions, deletions, substitutions))
+        previous_row = current_row
+
+    return previous_row[-1]
+

--- a/log patterns.py
+++ b/log patterns.py
@@ -3,8 +3,10 @@
 import csv
 import json
 import sys
+from operator import itemgetter
 
 import patterns
+import levenshtein
 
 
 def eprint(*args, **kwargs):
@@ -13,24 +15,42 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 
-def convert_id2nnames(name2id, patterns):
+
+def _convert_id2nnames(name2id, patterns):
     id2name = {}
     for name, idv in name2id.items():
         id2name[idv] = name
 
-    npatterns = {}
-    for pattern, times in patterns.items():
+    npatterns = []
+    for pattern, times in patterns:
         pl = []
         for element in pattern:
             pl.append(id2name[element])
-        npatterns[tuple(pl)] = times
+        npatterns.append( (tuple(pl), times) )
+
     return npatterns
 
 
-def real_main(min_length, csvlog_fn, jsonnumber_fn, numbers):
-    with open(jsonnumber_fn, 'r') as jsonnumber:
-        name2id = json.load(jsonnumber)
 
+def _distance_from(ibase):
+    def key(v):
+        return ( levenshtein.levenshtein(v[0], ibase), -v[1] )
+    return key
+
+
+
+def _sort_results(found_patterns, sort_by):
+    if sort_by != None:
+        keyf = _distance_from(sort_by)
+        rev = False
+    else:
+        keyf = itemgetter(1)
+        rev = True
+    return sorted( [ x for x in found_patterns.items() ], key=keyf, reverse=rev )
+
+
+
+def _read_actions(csvlog_fn, name2id):
     actions = []
     with open(csvlog_fn, 'r') as csvlog:
         csvlog_reader = csv.reader(csvlog)
@@ -39,16 +59,29 @@ def real_main(min_length, csvlog_fn, jsonnumber_fn, numbers):
             if first:
                 first = False
                 if row[1] != 'actionName':
-                    eprint('Error, the second column is not "actionName", are you sure this is a log?')
-                    return 1
+                    return None
             else:
                 actions.append( name2id[row[1]] )
+    return actions
+
+
+
+def real_main(min_length, csvlog_fn, jsonnumber_fn, numbers, sort_by):
+    with open(jsonnumber_fn, 'r') as jsonnumber:
+        name2id = json.load(jsonnumber)
+
+    actions = _read_actions(csvlog_fn, name2id)
+    if actions == None:
+        eprint('Error, the second column is not "actionName", are you sure this is a log?')
+        return 1
 
     found_patterns = patterns.find_repetitions(actions, min_length)
-    if not numbers:
-        found_patterns = convert_id2nnames(name2id, found_patterns)
+    found_patterns = _sort_results(found_patterns, sort_by)
 
-    for itm, times in found_patterns.items():
+    if not numbers:
+        found_patterns = _convert_id2nnames(name2id, found_patterns)
+
+    for itm, times in found_patterns:
         print(times, ":", itm)
 
     return 0
@@ -61,6 +94,7 @@ def main(argv=None):
         If it's a normal function argv won't be None if started by the OS
         argv is initialized by the command line arguments
     """
+
     if argv is None:
         argv = sys.argv
 
@@ -68,15 +102,24 @@ def main(argv=None):
         min_length = int(argv[1])
         csvlog = argv[2]
         jsonnumber = argv[3]
-        numbers = len(argv) > 4 and argv[4] == '-n'
+
+        numbers = False
+        sort_by = None
+
+        for idx in range(4, len(argv)):
+            if argv[idx] == '-n': numbers = True
+            elif argv[idx] == '-s' and len(argv) > idx + 1:
+                sort_by = tuple(int(x.strip()) for x in argv[idx + 1].split(','))
+
     except:
-        eprint('Usage: prg len cvslog json_numbers [-n]')
+        eprint('Usage: prg len cvslog json_numbers [-n] [-s 1,2,...,n]')
         eprint('')
         eprint('-n display output in numbers, instead of action names')
+        eprint('-s sort the results by distance from input sequence')
         eprint('')
         return 1
 
-    return real_main(min_length, csvlog, jsonnumber, numbers)
+    return real_main(min_length, csvlog, jsonnumber, numbers, sort_by)
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
 log patterns.py now shorts by how common a pattern is and, with -s, it is possible to sort by distance from an input pattern. The input pattern can only be numeric.